### PR TITLE
Update to only show on Zen.

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -16,5 +16,6 @@
         "Better"
     ],
     "createdAt": "2025-05-26",
-    "updatedAt": "2025-05-26"
+    "updatedAt": "2025-05-26",
+    "fork": ["zen"]
 }


### PR DESCRIPTION
@Darsh-A Sine will be adding cross-browser support soon, and as such, I am adding a property to only show mods when they are compatible with the user's browser. That's what this pr does.